### PR TITLE
Rename file to prevent compilation error

### DIFF
--- a/Assets/Scripts/MichaelAngeloRoomScripter.cs
+++ b/Assets/Scripts/MichaelAngeloRoomScripter.cs
@@ -2,7 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class RoomScripter : MonoBehaviour
+public class MichaelAngeloRoomScripter : MonoBehaviour
 {
     private RoomManager roomManager;
     public Textures textures;


### PR DESCRIPTION
The MichaelAngeloRoomScripter and RoomScripter had the same class name, preventing Unity from compiling / running the game.

Changed MichaelAngeloRoomScripter class name to match file name.